### PR TITLE
修复当dataSourceObjects为null时，点击"点击重试"按钮时，出现NPE的问题

### DIFF
--- a/jiaozivideoplayer/src/main/java/cn/jzvd/JZVideoPlayerStandard.java
+++ b/jiaozivideoplayer/src/main/java/cn/jzvd/JZVideoPlayerStandard.java
@@ -332,6 +332,10 @@ public class JZVideoPlayerStandard extends JZVideoPlayer {
             layout.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
             clarityPopWindow.update(clarity, -40, 46, Math.round(layout.getMeasuredWidth() * 2), layout.getMeasuredHeight());
         } else if (i == R.id.retry_btn) {
+            if (dataSourceObjects == null || JZUtils.getCurrentFromDataSource(dataSourceObjects, currentUrlMapIndex) == null) {
+                Toast.makeText(getContext(), getResources().getString(R.string.no_url), Toast.LENGTH_SHORT).show();
+                return;
+            }
             if (!JZUtils.getCurrentFromDataSource(dataSourceObjects, currentUrlMapIndex).toString().startsWith("file") && !
                     JZUtils.getCurrentFromDataSource(dataSourceObjects, currentUrlMapIndex).toString().startsWith("/") &&
                     !JZUtils.isWifiConnected(getContext()) && !WIFI_TIP_DIALOG_SHOWED) {


### PR DESCRIPTION
修复当dataSourceObjects为null时，点击"点击重试"按钮时，出现NPE的问题
希望能尽快merge&release，十分感谢 !!!@lipangit 