### PR TITLE
Fixing seekTo loop

### DIFF
--- a/app/src/main/java/cn/jzvd/demo/CustomMediaPlayer/JZExoPlayer.java
+++ b/app/src/main/java/cn/jzvd/demo/CustomMediaPlayer/JZExoPlayer.java
@@ -50,11 +50,12 @@ public class JZExoPlayer extends JZMediaInterface implements Player.EventListene
     private Runnable callback;
     private String TAG = "JZExoPlayer";
     private MediaSource videoSource;
+    private long previousSeek = 0;
+
 
     @Override
     public void start() {
         simpleExoPlayer.setPlayWhenReady(true);
-        simpleExoPlayer.getPlaybackState();
     }
 
     @Override
@@ -83,7 +84,7 @@ public class JZExoPlayer extends JZMediaInterface implements Player.EventListene
                 Util.getUserAgent(context, context.getResources().getString(R.string.app_name)));
 
         String currUrl = currentDataSource.toString();
-        if (currUrl.contains(".m3u8") == true) {
+        if (currUrl.contains(".m3u8")) {
             videoSource = new HlsMediaSource.Factory(dataSourceFactory)
                     .createMediaSource(Uri.parse(currUrl), mainHandler, null);
         } else {
@@ -139,7 +140,6 @@ public class JZExoPlayer extends JZMediaInterface implements Player.EventListene
     @Override
     public void pause() {
         simpleExoPlayer.setPlayWhenReady(false);
-        simpleExoPlayer.getPlaybackState();
     }
 
     @Override
@@ -149,7 +149,11 @@ public class JZExoPlayer extends JZMediaInterface implements Player.EventListene
 
     @Override
     public void seekTo(long time) {
-        simpleExoPlayer.seekTo(time);
+        if(time != previousSeek) {
+            simpleExoPlayer.seekTo(time);
+            previousSeek = time;
+            JZVideoPlayerManager.getCurrentJzvd().seekToInAdvance = time;
+        }
     }
 
     @Override


### PR DESCRIPTION
Problem: after calling seekTo and closing the player, when it is reopened it gets stuck in the previous saved position.

This "freezing behaviour" is caused by a loop in this flow:
- In JZExoPlayer:
    - seekTo()
    - onPrepared() (inside onPlayerStateChanged)
- In JZVideoPlayer:
    - onStatePrepared() (it calls seekTo())

Solution 1: So, the easiest way to solve this problem was verifying the time passed to seekTo. If is the same than the previous one, just ignore it.

Solution 2: This problem can be solved changing the way we dealing with Surface object on handleMessage method in JZMediaManager (but I didn't have success) as can be seen in this links:

https://github.com/google/ExoPlayer/issues/2703#issuecomment-300599981
https://github.com/google/ExoPlayer/issues/2441#issuecomment-279772415