### PR TITLE
Avoiding NPE

### DIFF
--- a/jiaozivideoplayer/src/main/java/cn/jzvd/JZVideoPlayer.java
+++ b/jiaozivideoplayer/src/main/java/cn/jzvd/JZVideoPlayer.java
@@ -80,8 +80,9 @@ public abstract class JZVideoPlayer extends FrameLayout implements View.OnClickL
                     break;
                 case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
                     try {
-                        if (JZVideoPlayerManager.getCurrentJzvd().currentState == JZVideoPlayer.CURRENT_STATE_PLAYING) {
-                            JZVideoPlayerManager.getCurrentJzvd().startButton.performClick();
+                        JZVideoPlayer player = JZVideoPlayerManager.getCurrentJzvd();
+                        if (player != null && player.currentState == JZVideoPlayer.CURRENT_STATE_PLAYING) {
+                            player.startButton.performClick();
                         }
                     } catch (IllegalStateException e) {
                         e.printStackTrace();


### PR DESCRIPTION
Sometimes when changing apps, the background app could throw a NPE in this line. Just avoiding this behaviour.