### PR TITLE
Fixing bug when playing mp4

### DIFF
--- a/jiaozivideoplayer/src/main/java/cn/jzvd/JZMediaSystem.java
+++ b/jiaozivideoplayer/src/main/java/cn/jzvd/JZMediaSystem.java
@@ -105,16 +105,14 @@ public class JZMediaSystem extends JZMediaInterface implements MediaPlayer.OnPre
     @Override
     public void onPrepared(MediaPlayer mediaPlayer) {
         mediaPlayer.start();
-        if (currentDataSource.toString().toLowerCase().contains("mp3")) {
-            JZMediaManager.instance().mainThreadHandler.post(new Runnable() {
-                @Override
-                public void run() {
-                    if (JZVideoPlayerManager.getCurrentJzvd() != null) {
-                        JZVideoPlayerManager.getCurrentJzvd().onPrepared();
-                    }
+        JZMediaManager.instance().mainThreadHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                if (JZVideoPlayerManager.getCurrentJzvd() != null) {
+                    JZVideoPlayerManager.getCurrentJzvd().onPrepared();
                 }
-            });
-        }
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
Problem: when playing mp4 using JZMediaSystem with JZVideoPlayerStandard, the loading overlay doesn't hide, so the player can't show the playback controls.

Why: because file extension mp4, the JZMediaSystem class can't call getCurrentJzvd().onPrepared that delegates to onStatePlaying.

Solution: just remove this verification.