### PR TITLE
添加无缝播放功能

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -82,6 +82,14 @@
             android:configChanges="orientation|screenSize|keyboardHidden"
             android:screenOrientation="portrait" />
         <activity
+            android:name=".ActivityRecyclerViewSeamlessPlay"
+            android:configChanges="orientation|screenSize|keyboardHidden"
+            android:screenOrientation="portrait" />
+        <activity
+            android:name=".DetailVideoSeamlessPlay"
+            android:configChanges="orientation|screenSize|keyboardHidden"
+            android:screenOrientation="portrait" />
+        <activity
             android:name=".ActivityWebView"
             android:configChanges="orientation|screenSize|keyboardHidden"
             android:screenOrientation="portrait" />

--- a/app/src/main/java/cn/jzvd/demo/ActivityListView.java
+++ b/app/src/main/java/cn/jzvd/demo/ActivityListView.java
@@ -51,4 +51,8 @@ public class ActivityListView extends AppCompatActivity {
     public void clickRecyclerView(View view) {
         startActivity(new Intent(ActivityListView.this, ActivityListViewRecyclerView.class));
     }
+
+    public void clickRecyclerViewSeamlessPlay(View view) {
+        startActivity(new Intent(ActivityListView.this, ActivityRecyclerViewSeamlessPlay.class));
+    }
 }

--- a/app/src/main/java/cn/jzvd/demo/ActivityRecyclerViewSeamlessPlay.java
+++ b/app/src/main/java/cn/jzvd/demo/ActivityRecyclerViewSeamlessPlay.java
@@ -1,0 +1,189 @@
+package cn.jzvd.demo;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Bundle;
+import android.os.Handler;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import cn.jzvd.JZUtils;
+import cn.jzvd.Jzvd;
+import cn.jzvd.JzvdStd;
+
+import static cn.jzvd.Jzvd.backPress;
+
+/**
+ * Created by yujunkui on 16/8/29.
+ */
+public class ActivityRecyclerViewSeamlessPlay extends AppCompatActivity implements AdapterRecyclerViewSeamlessPlay.OnListListener {
+
+    public static final String notification_detail_video_back_to_list = "notification_detail_video_back_to_list";
+    RecyclerView recyclerView;
+    AdapterRecyclerViewSeamlessPlay adapterVideoList;
+    private boolean isKeepPlayingToDetail = false;  //无缝播放使用
+    private DetailVideoBackReceiver detailVideoBackReceiver;
+    private Handler handler = new Handler();
+    private LinearLayoutManager linearLayoutManager;
+    private int screenWidth, screenHeight;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setDisplayShowHomeEnabled(true);
+        getSupportActionBar().setDisplayShowTitleEnabled(true);
+        getSupportActionBar().setDisplayUseLogoEnabled(false);
+        getSupportActionBar().setTitle("RecyclerView");
+        setContentView(R.layout.activity_recyclerview_content);
+
+        screenWidth = JZUtils.getScreenWidth(this);
+        screenHeight = JZUtils.getScreenHeight(this);
+
+        recyclerView = findViewById(R.id.recyclerview);
+        linearLayoutManager=new LinearLayoutManager(this);
+        recyclerView.setLayoutManager(linearLayoutManager);
+
+        adapterVideoList = new AdapterRecyclerViewSeamlessPlay(this);
+        recyclerView.setAdapter(adapterVideoList);
+        adapterVideoList.setOnListListener(this);
+
+        //这样判断更严谨，video的部分一划出界面就释放资源.
+        recyclerView.addOnScrollListener(scrollListener);
+        initVideoBackReceiver();
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                finish();
+                break;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void onInfoClick(String title,String url, String thumbUrl,int position) {
+        if (Jzvd.CURRENT_JZVD == null) {
+            Intent intent = new Intent(this, DetailVideoSeamlessPlay.class);
+            intent.putExtra("url", url);
+            startActivity(intent);
+        } else {
+            isKeepPlayingToDetail = true;
+            Intent intent = new Intent(this, DetailVideoSeamlessPlay.class);
+            intent.putExtra("currentPlayPosition", position);
+            intent.putExtra("isKeepPlaying", true);
+            intent.putExtra("title", title);
+            intent.putExtra("url", url);
+            intent.putExtra("thumbUrl", thumbUrl);
+            startActivity(intent);
+        }
+    }
+
+    private RecyclerView.OnScrollListener scrollListener = new RecyclerView.OnScrollListener() {
+        @Override
+        public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
+            super.onScrollStateChanged(recyclerView, newState);
+        }
+
+        @Override
+        public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
+            super.onScrolled(recyclerView, dx, dy);
+            if (Jzvd.CURRENT_JZVD != null) {
+                if (!JZUtils.isVisible(screenWidth, screenHeight,Jzvd.CURRENT_JZVD)) {
+                    Jzvd.releaseAllVideos();
+                }
+            }
+        }
+    };
+
+    private void initVideoBackReceiver() {
+        //不判断可能会接收多次
+        if (detailVideoBackReceiver == null) {
+            detailVideoBackReceiver = new DetailVideoBackReceiver();
+            IntentFilter intentFilter = new IntentFilter();
+            intentFilter.addAction(notification_detail_video_back_to_list);
+            registerReceiver(detailVideoBackReceiver, intentFilter);
+        }
+    }
+
+    class DetailVideoBackReceiver extends BroadcastReceiver {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            int currentPlayPosition = intent.getIntExtra("currentPlayPosition", -1);
+            onPlayVideoBack(currentPlayPosition);
+        }
+    }
+
+    //detail video back回调
+    public void onPlayVideoBack(int currentPlayPosition) {
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                int first = linearLayoutManager.findFirstVisibleItemPosition();
+                View view = recyclerView.getChildAt(currentPlayPosition - first);
+                if (view != null) {
+                    FrameLayout playerContainer = view.findViewById(R.id.container);
+                    playerContainer.removeAllViews();
+                    JzvdStd player = (JzvdStd) Jzvd.CURRENT_JZVD;
+                    //这种情况是该视频在详情页正在播
+                    if (player != null) {
+                        player.attachToContainer(player,playerContainer);
+                        //下面这行注释掉可在列表页继续无缝播放，但是全屏的时候由于该视频现在是详情页传过来的，
+                        //现在引用的是详情页的Context，所以还会有问题，还需要切换Context。
+                        Jzvd.releaseAllVideos();
+                        //这种情况是该视频在详情页播完了
+                    }else {
+                        recyclerView.setAdapter(adapterVideoList);
+                    }
+                }
+            }
+        }, 500);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        //无缝播放
+        if (!isKeepPlayingToDetail) {
+            JzvdStd.goOnPlayOnPause();
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        isKeepPlayingToDetail = false;
+        JzvdStd.goOnPlayOnResume();
+    }
+
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        handler.removeCallbacksAndMessages(null);
+        Jzvd.releaseAllVideos();
+        if (recyclerView != null) {
+            recyclerView.removeOnScrollListener(scrollListener);
+        }
+        if (detailVideoBackReceiver != null) {
+            unregisterReceiver(detailVideoBackReceiver);
+        }
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (backPress()) {
+            return;
+        }
+        super.onBackPressed();
+    }
+}

--- a/app/src/main/java/cn/jzvd/demo/AdapterRecyclerViewSeamlessPlay.java
+++ b/app/src/main/java/cn/jzvd/demo/AdapterRecyclerViewSeamlessPlay.java
@@ -1,0 +1,85 @@
+package cn.jzvd.demo;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.support.v7.widget.RecyclerView;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+
+import com.bumptech.glide.Glide;
+
+import cn.jzvd.Jzvd;
+import cn.jzvd.JzvdStd;
+
+public class AdapterRecyclerViewSeamlessPlay extends RecyclerView.Adapter<AdapterRecyclerViewSeamlessPlay.MyViewHolder> {
+
+    public static final String TAG = "AdapterRecyclerView";
+    int[] videoIndexs = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    private Context context;
+    private OnListListener onListListener;
+
+    public AdapterRecyclerViewSeamlessPlay(Context context) {
+        this.context = context;
+    }
+
+    @Override
+    public MyViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        MyViewHolder holder = new MyViewHolder(LayoutInflater.from(
+                context).inflate(R.layout.item_video_seamless_play, parent,
+                false));
+        return holder;
+    }
+
+    @SuppressLint("LongLogTag")
+    @Override
+    public void onBindViewHolder(MyViewHolder holder, int position) {
+        Log.i(TAG, "onBindViewHolder [" + holder.jzvdStd.hashCode() + "] position=" + position);
+
+        holder.jzvdStd.setUp(
+                VideoConstant.videoUrls[0][position],
+                VideoConstant.videoTitles[0][position], Jzvd.SCREEN_NORMAL);
+        Glide.with(holder.jzvdStd.getContext()).load(VideoConstant.videoThumbs[0][position]).into(holder.jzvdStd.thumbImageView);
+
+        holder.infoLayout.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (onListListener!=null){
+                    onListListener.onInfoClick(VideoConstant.videoTitles[0][position],
+                            VideoConstant.videoUrls[0][position], VideoConstant.videoThumbs[0][position], position);
+                }
+            }
+        });
+
+    }
+
+    @Override
+    public int getItemCount() {
+        return videoIndexs.length;
+    }
+
+    class MyViewHolder extends RecyclerView.ViewHolder {
+        JzvdStd jzvdStd;
+        LinearLayout infoLayout;
+
+        public MyViewHolder(View itemView) {
+            super(itemView);
+            jzvdStd = itemView.findViewById(R.id.videoplayer);
+            infoLayout = itemView.findViewById(R.id.infoLayout);
+        }
+    }
+
+    public interface OnListListener {
+        void onInfoClick(String title, String url, String thumbUrl, int position);
+    }
+
+    public void setOnListListener(OnListListener onListListener) {
+        this.onListListener = onListListener;
+    }
+
+
+
+
+}

--- a/app/src/main/java/cn/jzvd/demo/DetailVideoSeamlessPlay.java
+++ b/app/src/main/java/cn/jzvd/demo/DetailVideoSeamlessPlay.java
@@ -1,0 +1,133 @@
+package cn.jzvd.demo;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import com.bumptech.glide.Glide;
+
+import cn.jzvd.Jzvd;
+import cn.jzvd.JzvdStd;
+
+import static cn.jzvd.Jzvd.SCREEN_FULLSCREEN;
+import static cn.jzvd.Jzvd.STATE_AUTO_COMPLETE;
+import static cn.jzvd.Jzvd.backPress;
+
+/**
+ * Created by yujunkui on 16/8/29.
+ */
+public class DetailVideoSeamlessPlay extends AppCompatActivity {
+    private boolean isKeepPlaying;
+    private FrameLayout playerContainer;
+    private int currentPlayPosition;
+    private JzvdStd videoPlayer;
+    private String title, url, thumbUrl;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        getSupportActionBar().setDisplayShowHomeEnabled(true);
+        getSupportActionBar().setDisplayShowTitleEnabled(true);
+        getSupportActionBar().setDisplayUseLogoEnabled(false);
+        getSupportActionBar().setTitle("DetailVideo");
+        setContentView(R.layout.activity_detail_video);
+
+        Intent intent = getIntent();
+        currentPlayPosition = intent.getIntExtra("currentPlayPosition", 0);
+        isKeepPlaying = getIntent().getBooleanExtra("isKeepPlaying", false);
+        title = getIntent().getStringExtra("title");
+        url = getIntent().getStringExtra("url");
+        thumbUrl = getIntent().getStringExtra("thumbUrl");
+
+        playerContainer = findViewById(R.id.container);
+        videoPlayer = findViewById(R.id.video_player);
+
+        initVideoPlayer();
+
+    }
+
+    private void initVideoPlayer() {
+        // 无缝播放
+        if (isKeepPlaying) {
+            playerContainer.removeAllViews();
+            JzvdStd player = (JzvdStd) Jzvd.CURRENT_JZVD;
+            if (player != null) {
+                player.attachToContainer(player, playerContainer);
+                player.fullscreenButton.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        if (player.state == STATE_AUTO_COMPLETE) return;
+                        //这里必须要传当前详情页的Context进去，因为当前的player是从列表页传过来的，
+                        // 不传Context的话引用的Context仍然是列表页的，会引起功能失效。
+                        if (player.screen == SCREEN_FULLSCREEN) {
+                            player.backPress(DetailVideoSeamlessPlay.this);
+                        } else {
+                            player.gotoScreenFullscreenForResumePlay(DetailVideoSeamlessPlay.this);
+                        }
+                    }
+                });
+                player.backButton.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        if (player.screen == SCREEN_FULLSCREEN) {
+                            player.backPress(DetailVideoSeamlessPlay.this);
+                        }
+                    }
+                });
+            }
+            //正常播放
+        } else {
+            videoPlayer.setUp(url, title, Jzvd.SCREEN_NORMAL);
+            Glide.with(DetailVideoSeamlessPlay.this).load(thumbUrl).into(videoPlayer.thumbImageView);
+            videoPlayer.startVideo();
+        }
+    }
+
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        JzvdStd.goOnPlayOnPause();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        JzvdStd.goOnPlayOnResume();
+    }
+
+
+    @Override
+    public void onBackPressed() {
+        //无缝播放的返回
+        if (isKeepPlaying) {
+            if (backPress(DetailVideoSeamlessPlay.this)) {
+                return;
+            }
+            //这里可以用事件总线来做，现在一个就用sendBroadcast了
+            Intent intent = new Intent(ActivityRecyclerViewSeamlessPlay.notification_detail_video_back_to_list);
+            intent.putExtra("currentPlayPosition", currentPlayPosition);
+            sendBroadcast(intent);
+            //正常播放的返回
+        } else {
+            if (backPress()) {
+                return;
+            }
+        }
+        super.onBackPressed();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        //无缝播放回到列表页之前不能停止视频
+        if (!isKeepPlaying) {
+            Jzvd.releaseAllVideos();
+        }
+    }
+
+}

--- a/app/src/main/res/layout/activity_detail_video.xml
+++ b/app/src/main/res/layout/activity_detail_video.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <FrameLayout
+        android:id="@+id/container"
+        android:layout_height="200dp"
+        android:layout_width="match_parent">
+
+        <cn.jzvd.JzvdStd
+            android:id="@+id/video_player"
+            android:layout_height="match_parent"
+            android:layout_width="match_parent"/>
+    </FrameLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_listview.xml
+++ b/app/src/main/res/layout/activity_listview.xml
@@ -36,4 +36,12 @@
         android:layout_gravity="center_horizontal"
         android:onClick="clickRecyclerView"
         android:text="Recyleview" />
+
+    <Button
+        android:id="@+id/recyleviewSeamlessPlay"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:onClick="clickRecyclerViewSeamlessPlay"
+        android:text="RecyleviewSeamlessPlay" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_video_seamless_play.xml
+++ b/app/src/main/res/layout/item_video_seamless_play.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <FrameLayout
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="200dp">
+
+        <cn.jzvd.JzvdStd
+            android:id="@+id/videoplayer"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </FrameLayout>
+
+    <LinearLayout
+        android:id="@+id/infoLayout"
+        android:layout_width="match_parent"
+        android:layout_height="60dp"
+        android:gravity="center"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:text="这里是title"
+            android:textColor="@android:color/darker_gray"
+            android:textSize="20dp" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/jiaozivideoplayer/src/main/java/cn/jzvd/JZUtils.java
+++ b/jiaozivideoplayer/src/main/java/cn/jzvd/JZUtils.java
@@ -5,12 +5,12 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
+import android.graphics.Rect;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
-import android.support.v4.app.ActivityCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.view.ContextThemeWrapper;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.View;
 import android.view.Window;
@@ -185,5 +185,38 @@ public class JZUtils {
         int uiOptions = View.SYSTEM_UI_FLAG_VISIBLE;
         JZUtils.getWindow(context).getDecorView().setSystemUiVisibility(SYSTEM_UI);
     }
+
+
+
+    public static int getScreenWidth(Context context) {
+        DisplayMetrics dm = context.getResources().getDisplayMetrics();
+        return dm.widthPixels;
+    }
+
+    public static int getScreenHeight(Context context) {
+        DisplayMetrics dm = context.getResources().getDisplayMetrics();
+        return dm.heightPixels;
+    }
+
+    /**
+     * 判断view在屏幕中是否可见
+     *
+     * @param view
+     * @return
+     */
+    public static boolean isVisible(int screenWidth, int screenHeight ,View view) {
+        if (view == null) {
+            return false;
+        }
+        Rect rect = new Rect(0, 0, screenWidth, screenHeight);
+        int[] location = new int[2];
+        view.getLocationInWindow(location);
+        if (view.getLocalVisibleRect(rect)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
 
 }

--- a/jiaozivideoplayer/src/main/java/cn/jzvd/Jzvd.java
+++ b/jiaozivideoplayer/src/main/java/cn/jzvd/Jzvd.java
@@ -751,6 +751,22 @@ public abstract class Jzvd extends FrameLayout implements View.OnClickListener, 
 
     }
 
+    public void gotoScreenFullscreenForResumePlay(Context context) {
+        ViewGroup vg = (ViewGroup) getParent();
+        vg.removeView(this);
+        cloneAJzvd(vg);
+        CONTAINER_LIST.add(vg);
+        ViewGroup decorView = (ViewGroup) (JZUtils.scanForActivity(context)).getWindow().getDecorView();//和他也没有关系
+        decorView.addView(this, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+
+        setScreenFullscreen();
+        JZUtils.hideStatusBar(context);
+        JZUtils.setRequestedOrientation(context, FULLSCREEN_ORIENTATION);
+        JZUtils.hideSystemUI(context);//华为手机和有虚拟键的手机全屏时可隐藏虚拟键 issue:1326
+    }
+
+
     public void gotoScreenNormal() {//goback本质上是goto
         gobakFullscreenTime = System.currentTimeMillis();//退出全屏
         ViewGroup vg = (ViewGroup) (JZUtils.scanForActivity(getContext())).getWindow().getDecorView();
@@ -764,6 +780,26 @@ public abstract class Jzvd extends FrameLayout implements View.OnClickListener, 
         JZUtils.showStatusBar(getContext());
         JZUtils.setRequestedOrientation(getContext(), NORMAL_ORIENTATION);
         JZUtils.showSystemUI(getContext());
+    }
+
+
+    public void gotoScreenNormalForResumePlay(Context context) {//goback本质上是goto
+        gobakFullscreenTime = System.currentTimeMillis();//退出全屏
+        ViewGroup decorView = (ViewGroup) (JZUtils.scanForActivity(context)).getWindow().getDecorView();
+        decorView.removeView(this);
+        ViewGroup vg = (ViewGroup) getParent();
+        if (vg != null) {
+            vg.removeView(this);
+        }
+        CONTAINER_LIST.getLast().removeAllViews();
+        CONTAINER_LIST.getLast().addView(this, new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+        CONTAINER_LIST.pop();
+
+        setScreenNormal();//这块可以放到jzvd中
+        JZUtils.showStatusBar(context);
+        JZUtils.setRequestedOrientation(context, NORMAL_ORIENTATION);
+        JZUtils.showSystemUI(context);
     }
 
     public void setScreenNormal() {//TODO 这块不对呀，还需要改进，设置flag之后要设置ui，不设置ui这么写没意义呀
@@ -984,6 +1020,20 @@ public abstract class Jzvd extends FrameLayout implements View.OnClickListener, 
         return false;
     }
 
+    //要使用无缝播放的详情页用
+    public static boolean backPress(Context context) {
+        Log.i(TAG, "backPress");
+        if (CONTAINER_LIST.size() != 0 && CURRENT_JZVD != null) {//判断条件，因为当前所有goBack都是回到普通窗口
+            CURRENT_JZVD.gotoScreenNormalForResumePlay(context);
+            return true;
+        } else if (CONTAINER_LIST.size() == 0 && CURRENT_JZVD != null && CURRENT_JZVD.screen != SCREEN_NORMAL) {//退出直接进入的全屏
+            CURRENT_JZVD.clearFloatScreen();
+            return true;
+        }
+        return false;
+    }
+
+
     public static void setCurrentJzvd(Jzvd jzvd) {
         if (CURRENT_JZVD != null) CURRENT_JZVD.reset();
         CURRENT_JZVD = jzvd;
@@ -1003,6 +1053,22 @@ public abstract class Jzvd extends FrameLayout implements View.OnClickListener, 
         Jzvd.VIDEO_IMAGE_DISPLAY_TYPE = type;
         if (CURRENT_JZVD != null && CURRENT_JZVD.textureView != null) {
             CURRENT_JZVD.textureView.requestLayout();
+        }
+    }
+
+
+    public void attachToContainer(Jzvd player,ViewGroup container) {
+        detachSuperContainer(player);
+        if (container != null) {
+            container.addView(player, new FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+        }
+    }
+
+    public void detachSuperContainer(Jzvd player) {
+        ViewParent parent = player.getParent();
+        if (parent != null && parent instanceof ViewGroup) {
+            ((ViewGroup) parent).removeView(player);
         }
     }
 


### PR DESCRIPTION
说明：
1、ActivityRecyclerViewSeamlessPlay：无缝播放的列表页
2、DetailVideoSeamlessPlay ： 无缝播放的详情页
3、列表进入详情已经实现了无缝播放，详情回到列表也实现了无缝播放，只是回来的时候全屏还要问题，原因是Context没有转换过来，这个我在代码里有注释。

4、另外，视频列表如果带有title信息，如我demo中的列表，这时候正在播放的视频划出屏幕要释放视频的判断不是很严谨，这个我也添加了代码。

原理：
1、列表进入详情：将正在播放的视频直接传到详情页，用详情页的容器去添加。由于该视频之前引用的Context是列表页的Context，所以详情页中进行相关视频的操作的时候要切换为详情页的Context。
2、详情返回列表：如上同理，需要将详情页中传过来的Context转换成列表页的Context，才能进行视频的相关操作。